### PR TITLE
Add a condition if dataDir don't exist anymore

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,7 @@
 var moment = require('moment');
 var path = require('path');
+var mkdirp = require('mkdirp');
+var fs = require('fs');
 
 module.exports = function (rl, done) {
     var HOME = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
@@ -15,24 +17,26 @@ module.exports = function (rl, done) {
     config = config || {};
 
     if (!config.startDate || !config.dataDir) {
-        var mkdirp = require('mkdirp');
-        var fs = require('fs');
-        rl.question("Where should we store the data? ", function (answer) {
-            answer = answer.trim();
-            if (answer[0] === '~') {
-                answer = path.join(HOME, answer.substr(1));
-            }
-
-            config.dataDir = answer;
-            config.startDate = moment().subtract({ days: 3 }).format('YYYY-MM-DD');
-
-            mkdirp(answer, function (err) {
-                fs.writeFile(configFile, JSON.stringify(config, null, 2), function () {
-                    done(config);
-                });
-            });
-        });
+        rl.question("Where should we store the data? ", createDir);
+    } else if (!fs.existsSync(config.dataDir)) {
+        rl.question("Original store path: " + config.dataDir + " don't exist anymore, Where should we store the data? ", createDir);
     } else {
         done(config);
+    }
+
+    function createDir(answer) {
+        answer = answer.trim();
+        if (answer[0] === '~') {
+            answer = path.join(HOME, answer.substr(1));
+        }
+
+        config.dataDir = answer;
+        config.startDate = moment().subtract({ days: 3 }).format('YYYY-MM-DD');
+
+        mkdirp(answer, function (err) {
+            fs.writeFile(configFile, JSON.stringify(config, null, 2), function () {
+                done(config);
+            });
+        });
     }
 };


### PR DESCRIPTION
If we delete the store directory before running track-your-damn-time.
It will throw error like this:

```
$ track-your-damn-time
What the heck did you do Last Thursday? (hours - task) 1 - the task
What else?
/Users/username/.npm_packages/lib/node_modules/track-your-damn-time/track-your-damn-time.js:100
        if (err) throw err;
                       ^
Error: ENOENT, open '/Users/username/newpath/2016-03-24.t1458748800000t'
    at Error (native)
```

To fix this, I add a condition in track-your-damn-time/lib/config.js checking dataDir exist or not.
If not, user will decide a new path to store the files in.
