### PR TITLE
Fix filename suffix when makeFilename

### DIFF
--- a/track-your-damn-time.js
+++ b/track-your-damn-time.js
@@ -66,7 +66,7 @@ function getMoreTimes(done) {
 }
 
 function makeFilename(date, dataDir) {
-    return path.join(dataDir, date.format("YYYY-MM-DD.txt"));
+    return path.join(dataDir, date.format("YYYY-MM-DD") + ".txt");
 }
 
 function checkAndPopulate(date, dataDir, done) {


### PR DESCRIPTION
Because 'x' in moment.js represent Unix ms timestamp, so `date.format("YYYY-MM-DD.txt")` will become like this:
2016-03-24.t1458748800000t
which cause the program not save the file correctly, and can't output the time tracking log.
