### PR TITLE
Add `add` and `append` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,30 @@
 
 **A poem:**
 
-I need to track time.  
-I never remember to track my time.  
-I tried things that tracked every minute of my day,  
-but that just made more data.  
-All I need to know is, roughly  
-What the heck did I do each day,  
-And for roughly how long?  
+I need to track time.
+I never remember to track my time.
+I tried things that tracked every minute of my day,
+but that just made more data.
+All I need to know is, roughly
+What the heck did I do each day,
+And for roughly how long?
 
-If I could remember to go to freshbooks,  
-And write those things down every day,  
-I would have no worries,  
+If I could remember to go to freshbooks,
+And write those things down every day,
+I would have no worries,
 But I don't.
-And I then have to try and remember what I did,  
-A month ago.  
+And I then have to try and remember what I did,
+A month ago.
 
-So I needed something that,  
-Would ask me every day,  
-"Yo, what the heck did you do yesterday?",  
-And save it somewhere.  
+So I needed something that,
+Would ask me every day,
+"Yo, what the heck did you do yesterday?",
+And save it somewhere.
 
-So that when I need to update freshbooks,  
-I don't have to get creative.  
+So that when I need to update freshbooks,
+I don't have to get creative.
 
-This is that thing.  
+This is that thing.
 
 ## What?
 
@@ -51,10 +51,22 @@ track-your-damn-time
 
 The first time it will ask you for a path to store the files in.
 
-## Logging
+## Commands
 
-To easily output your time tracking log, run:
+### Add Tasks
+Add new tasks for today. If tasks already exist for today, you'll be prompted to confirm overwrite:
+```
+track-your-damn-time add
+```
 
+### Append Tasks
+Append new tasks to today's existing tasks:
+```
+track-your-damn-time append
+```
+
+### View Log
+Output your time tracking log:
 ```
 track-your-damn-time log
 ```


### PR DESCRIPTION
Add `add` command to log today's tasks before the prompt.
When the log exists, prompt to user that he wants to replace existing content.

Add `append` command to append to today's tasks.